### PR TITLE
add header for "std::accumulate"

### DIFF
--- a/radar_ego_velocity_estimator/include/radar_ego_velocity_estimator/simple_profiler.h
+++ b/radar_ego_velocity_estimator/include/radar_ego_velocity_estimator/simple_profiler.h
@@ -21,7 +21,7 @@
 #include <unordered_map>
 #include <map>
 #include <chrono>
-
+#include <numeric>
 #include <yaml-cpp/yaml.h>
 
 #include <ros/console.h>


### PR DESCRIPTION
Hi Christopher,

Thank you very much for your work, a small fix when I tried to compile your package with ros melodic.
`/reve/radar_ego_velocity_estimator/src/simple_profiler.cpp:152:14: error: ‘accumulate’ is not a member of ‘std’
         std::accumulate(data->second.execution_ms.begin(), data->second.execution_ms.end(), 0.0f) /
`
reve proved to work on ros-melodic.

Best regards,
Wayne